### PR TITLE
fix: encoding failure leading text extraction to not tracks assets.

### DIFF
--- a/marie/executor/text/text_extraction_executor.py
+++ b/marie/executor/text/text_extraction_executor.py
@@ -6,7 +6,6 @@ from typing import Any, Optional, Union
 import numpy as np
 import torch
 from docarray import DocList
-
 from marie import Executor, requests, safely_encoded
 from marie.api import value_from_payload_or_args
 from marie.api.docs import AssetKeyDoc, StorageDoc
@@ -26,6 +25,7 @@ from marie.models.utils import (
     setup_torch_optimizations,
     torch_gc,
 )
+from marie.numpyencoder import NumpyEncoder
 from marie.ocr import CoordinateFormat
 from marie.pipe import ExtractPipeline
 from marie.storage import StorageManager
@@ -381,7 +381,7 @@ class TextExtractionExecutor(MarieExecutor, StorageMixin):
                                 bboxes.append(line["bbox"])
 
                 if bboxes:
-                    bbox_bytes = json.dumps(bboxes).encode("utf-8")
+                    bbox_bytes = json.dumps(bboxes, cls=NumpyEncoder).encode("utf-8")
                     bbox_version = AssetTracker.compute_asset_version(
                         payload_bytes=bbox_bytes,
                         code_fingerprint=getattr(self, "code_version", "unknown"),


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves completed extract not uploading using the AssetTracker. Example error
```
ERROR 2026-03-18 14:24:22,848:069bafba-d6aa-7ce3-8000-7b8e7de61a0b : TextExtractionExecutor[]@2050481 Extract error : Object of type int32 is not JSON                              
      serializable                                                                                                                                                                  
      Traceback (most recent call last):                                                                                                                                            
        File "/home/rsteele/dev/marieai/marie-ai/marie/executor/text/text_extraction_executor.py", line 238, in extract                                                             
          self.persist(                                                                                                                                                             
        File "/home/rsteele/dev/marieai/marie-ai/marie/executor/text/text_extraction_executor.py", line 384, in persist                                                             
          bbox_bytes = json.dumps(bboxes).encode("utf-8")                                                                                                                           
                       ^^^^^^^^^^^^^^^^^^                                                                                                                                           
        File "/usr/lib/python3.12/json/__init__.py", line 231, in dumps                                                                                                             
          return _default_encoder.encode(obj)                                                                                                                                       
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                       
        File "/usr/lib/python3.12/json/encoder.py", line 200, in encode                                                                                                             
          chunks = self.iterencode(o, _one_shot=True)                                                                                                                               
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                               
        File "/usr/lib/python3.12/json/encoder.py", line 258, in iterencode                                                                                                         
          return _iterencode(o, 0)                                                                                                                                                  
                 ^^^^^^^^^^^^^^^^^                                                                                                                                                  
        File "/usr/lib/python3.12/json/encoder.py", line 180, in default                                                                                                            
          raise TypeError(f'Object of type {o.__class__.__name__} '                                                                                                                 
      TypeError: Object of type int32 is not JSON serializable
```

Now with this fix, the upload completes successfully:
<img width="1423" height="334" alt="image" src="https://github.com/user-attachments/assets/432f8ae3-209b-44c3-9ecd-52006db7d560" />

- [ ] check and update documentation. See [guide](https://github.com/marieai/marie-ai/blob/main/CONTRIBUTING.md#-contributing-documentation) and ask the team.
