### PR TITLE
Feat: "Replace" Existing Work Policy 

### DIFF
--- a/config/psql/schema/021_resolve_dag_state.sql
+++ b/config/psql/schema/021_resolve_dag_state.sql
@@ -4,40 +4,32 @@ LANGUAGE plpgsql
 AS
 $$
 DECLARE
-    v_any_failed    BOOLEAN;
-    v_all_completed BOOLEAN;
     v_updated_rows  INT;
     v_new_state     TEXT := NULL;
 BEGIN
-    -- 1) If any job is "failed," mark the DAG as "failed."
-    SELECT EXISTS (
-        SELECT 1
-        FROM {schema}.job
-        WHERE dag_id = p_dag_id
-          AND state = 'failed'
-    )
-    INTO v_any_failed;
-
-    IF v_any_failed THEN
-        v_new_state := 'failed';
-
-    ELSE
-        -- 2) If all jobs are "completed," mark the DAG as "completed."
-        SELECT NOT EXISTS (
-            SELECT 1
-            FROM {schema}.job
-            WHERE dag_id = p_dag_id
-              AND state <> 'completed'
-        )
-        INTO v_all_completed;
-
-        IF v_all_completed THEN
-            v_new_state := 'completed';
-        ELSE
-            -- 3) Otherwise, mark the DAG as "active."
-            v_new_state := 'active';
-        END IF;
-    END IF;
+    SELECT CASE
+               -- 1) If any job is "failed," mark the DAG as "failed."
+               WHEN EXISTS (SELECT 1
+                            FROM {schema}.job
+                            WHERE dag_id = p_dag_id
+                              AND state = 'failed')
+                   THEN 'failed'
+               -- 2) If all jobs are "completed," mark the DAG as "completed."
+               WHEN NOT EXISTS (SELECT 1
+                                FROM {schema}.job
+                                WHERE dag_id = p_dag_id
+                                  AND state <> 'completed')
+                   THEN 'completed'
+               -- 3) If any jobs are "cancelled," mark the DAG as "cancelled."
+               WHEN EXISTS (SELECT 1
+                                FROM {schema}.job
+                                WHERE dag_id = p_dag_id
+                                  AND state = 'cancelled')
+                   THEN 'cancelled'
+               -- 4) Otherwise, mark the DAG as "active."
+               ELSE 'active'
+               END
+    INTO v_new_state;
 
     -- Update DAG state and completed_on
     UPDATE {schema}.dag

--- a/docs/docs/getting-started/job-management/api.md
+++ b/docs/docs/getting-started/job-management/api.md
@@ -457,7 +457,6 @@ from marie.scheduler.models import ExistingWorkPolicy
 ExistingWorkPolicy.ALLOW_ALL        # Accept all submissions
 ExistingWorkPolicy.REJECT_ALL       # Reject all submissions
 ExistingWorkPolicy.REPLACE          # Replace non-terminal jobs
-ExistingWorkPolicy.ALLOW_DUPLICATE  # Allow duplicate submissions
 ExistingWorkPolicy.REJECT_DUPLICATE # Reject duplicates (default)
 ```
 

--- a/marie/pipe/components.py
+++ b/marie/pipe/components.py
@@ -430,7 +430,10 @@ def burst_frames(
     :return:
     """
     output_dir = ensure_exists(os.path.join(root_asset_dir, "burst"))
+    # NOTE: filename = prefix = refId when refId is not a filename
     filename, prefix, suffix = split_filename(ref_id)
+    suffix = suffix or "tif"
+
     filename_generator = partial(filename_supplier_page, filename, prefix, suffix)
 
     file_count = get_file_count(output_dir)

--- a/marie/pipe/extract_pipeline.py
+++ b/marie/pipe/extract_pipeline.py
@@ -575,6 +575,7 @@ class ExtractPipeline(BasePipeline):
         adlib_dir = ensure_exists(os.path.join(root_asset_dir, "adlib"))
         self.logger.info(f"Rendering adlib : {adlib_dir}")
 
+        # NOTE: filename = prefix = refId when refId is not a filename
         filename, prefix, suffix = split_filename(ref_id)
         renderer = AdlibRenderer(summary_filename=f"{filename}.xml", config={})
 
@@ -582,7 +583,9 @@ class ExtractPipeline(BasePipeline):
             frames,
             results,
             adlib_dir,
-            filename_generator=lambda x: f"{prefix}_{x}.{suffix}.xml",
+            filename_generator=lambda x: (
+                f"{prefix}_{x}.xml" if not suffix else f"{prefix}_{x}.{suffix}.xml"
+            ),
         )
 
     def pack_assets(
@@ -597,8 +600,12 @@ class ExtractPipeline(BasePipeline):
 
         filename, prefix, suffix = split_filename(ref_id)
 
-        merge_zip(adlib_dir, os.path.join(assets_dir, f"{prefix}.ocr.zip"))
-        merge_zip(blob_dir, os.path.join(assets_dir, f"{prefix}.blobs.xml.zip"))
+        merge_zip(
+            adlib_dir, os.path.join(assets_dir, f"{prefix}.ocr.zip"), f"{prefix}*"
+        )
+        merge_zip(
+            blob_dir, os.path.join(assets_dir, f"{prefix}.blobs.xml.zip"), f"{prefix}*"
+        )
 
         # convert multiple to G4 standard (mulitpage) TIFF
         clean_filename = os.path.join(assets_dir, f"{prefix}.clean.tif")

--- a/marie/scheduler/models.py
+++ b/marie/scheduler/models.py
@@ -44,7 +44,6 @@ class ExistingWorkPolicy(Enum):
     ALLOW_ALL = "allow_all"  # allow all submissions
     REJECT_ALL = "reject_all"  # reject all submissions
     REPLACE = "replace"  # replace existing submission that is not in terminal state
-    ALLOW_DUPLICATE = "allow_duplicate"  # allow duplicate submissions
     REJECT_DUPLICATE = "reject_duplicate"  # reject duplicate submissions
 
     @staticmethod

--- a/marie/scheduler/psql.py
+++ b/marie/scheduler/psql.py
@@ -140,6 +140,20 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
         self.distributed_scheduler = config.get("distributed_scheduler", False)
 
         self._event_queue = Queue()
+
+        existing_work_policy = config.get("existing_work_policy")
+        try:
+            self.default_existing_work_policy = (
+                ExistingWorkPolicy[existing_work_policy.upper()]
+                if existing_work_policy is not None
+                else ExistingWorkPolicy.REJECT_DUPLICATE
+            )
+        except KeyError:
+            raise BadConfigSource(
+                f"Argument {existing_work_policy!r} is invalid for existing_work_policy. "
+                f"Must be one of {', '.join(ExistingWorkPolicy.__members__)}."
+            )
+
         self._status_update_lock = AsyncJobLock()
         self._dag_resolution_lock = AsyncJobLock()
         self._terminal_dag_states: dict[str, str] = {}
@@ -2182,7 +2196,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
 
         return work_item
 
-    async def get_job_for_policy(self, work_info: WorkInfo) -> Optional[WorkInfo]:
+    async def get_jobs_for_policy(self, work_info: WorkInfo) -> List[WorkInfo]:
         """
         Find a job by its name and data (used for policy checks).
         :param work_info: WorkInfo containing metadata with ref_type and ref_id
@@ -2192,6 +2206,42 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
         ref_id = work_info.data.get("metadata", {}).get("ref_id", "")
 
         return await self.repository.get_job_by_policy(ref_type, ref_id)
+        # todo
+        # results = []
+        # try:
+        #     conn = self._get_connection()
+        #     cursor = conn.cursor()
+        #     cursor.execute(
+        #         f"""
+        #             SELECT
+        #             id,
+        #             name,
+        #             priority,
+        #             state,
+        #             retry_limit,
+        #             start_after,
+        #             expire_in,
+        #             data,
+        #             retry_delay,
+        #             retry_backoff,
+        #             keep_until,
+        #             dag_id,
+        #             job_level
+        #         FROM {schema}.{table}
+        #         WHERE data->'metadata'->>'ref_type' = '{ref_type}'
+        #         AND data->'metadata'->>'ref_id' = '{ref_id}'
+        #         """
+        #     )
+        #     for record in cursor:
+        #         results.append(self.record_to_work_info(record))
+        #     conn.commit()
+        # except (Exception, psycopg2.Error) as error:
+        #     self.logger.error(f"Error getting job: {error}")
+        #     conn.rollback()
+        # finally:
+        #     self._close_cursor(cursor)
+        #     self._close_connection(conn)
+        # return results
 
     async def list_jobs(
         self, state: Optional[str | list[str]] = None, batch_size: int = 0
@@ -2406,7 +2456,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
         """
         submission_id = work_info.id
         submission_policy = ExistingWorkPolicy.create(
-            work_info.policy, default_policy=ExistingWorkPolicy.REJECT_DUPLICATE
+            work_info.policy, default_policy=self.default_existing_work_policy
         )
 
         is_valid = await self.is_valid_submission(work_info, submission_policy)
@@ -2584,17 +2634,35 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
             if policy == ExistingWorkPolicy.REJECT_ALL:
                 return False
 
-            existing_job = await self._loop.run_in_executor(
-                self._db_executor, self.get_job_for_policy, work_info
+            existing_jobs = await self._loop.run_in_executor(
+                self._db_executor, self.get_jobs_for_policy, work_info
             )
 
             if policy == ExistingWorkPolicy.REJECT_DUPLICATE:
-                return existing_job is None
+                return len(existing_jobs) == 0
 
             if policy == ExistingWorkPolicy.REPLACE:
-                return not existing_job or (
-                    existing_job.state is not None and existing_job.state.is_terminal()
-                )
+                if len(existing_jobs) == 0:
+                    return True
+
+                distinct_dag_ids = {
+                    job.dag_id for job in existing_jobs if job.dag_id is not None
+                }
+                for dag_id in distinct_dag_ids:
+                    dag_state = self._resolve_dag_status_sync(dag_id)
+                    if dag_state not in ("completed", "failed"):
+                        self.logger.warning(
+                            f"Removing DAG to due to 'replace' policy: {dag_id}, state: {dag_state}"
+                        )
+                        self._remove_dag_from_memory(
+                            dag_id, "Existing Work Policy: 'replace'"
+                        )
+                        is_deleted = await self.delete_dag(dag_id)
+                        if not is_deleted:
+                            self.logger.warning(f"Failed to delete DAG: {dag_id}")
+                            return False
+
+                return True
 
             raise ValueError(f"Unsupported policy: {policy}")
 
@@ -2604,6 +2672,28 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                 f"with policy '{policy}': {str(e)}"
             )
             return False
+
+    async def delete_dag(self, dag_id: str) -> bool:
+        self.logger.info(f"Deleting dag_id : {dag_id}")
+
+        # todo
+        def db_call():
+            cursor = None
+            conn = None
+            try:
+                conn = self._get_connection()
+                self._execute_sql_gracefully(
+                    delete_dags_and_jobs(DEFAULT_SCHEMA, [dag_id]), connection=conn
+                )
+                return True
+            except (Exception, psycopg2.Error) as error:
+                self.logger.error(f"Error completing failed job: {error}")
+                return False
+            finally:
+                self._close_cursor(cursor)
+                self._close_connection(conn)
+
+        return await self._loop.run_in_executor(self._db_executor, db_call)
 
     def stop_job(self, job_id: str) -> bool:
         """Request a job to exit, fire and forget.

--- a/marie/scheduler/psql.py
+++ b/marie/scheduler/psql.py
@@ -2205,43 +2205,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
         ref_type = work_info.data.get("metadata", {}).get("ref_type", "")
         ref_id = work_info.data.get("metadata", {}).get("ref_id", "")
 
-        return await self.repository.get_job_by_policy(ref_type, ref_id)
-        # todo
-        # results = []
-        # try:
-        #     conn = self._get_connection()
-        #     cursor = conn.cursor()
-        #     cursor.execute(
-        #         f"""
-        #             SELECT
-        #             id,
-        #             name,
-        #             priority,
-        #             state,
-        #             retry_limit,
-        #             start_after,
-        #             expire_in,
-        #             data,
-        #             retry_delay,
-        #             retry_backoff,
-        #             keep_until,
-        #             dag_id,
-        #             job_level
-        #         FROM {schema}.{table}
-        #         WHERE data->'metadata'->>'ref_type' = '{ref_type}'
-        #         AND data->'metadata'->>'ref_id' = '{ref_id}'
-        #         """
-        #     )
-        #     for record in cursor:
-        #         results.append(self.record_to_work_info(record))
-        #     conn.commit()
-        # except (Exception, psycopg2.Error) as error:
-        #     self.logger.error(f"Error getting job: {error}")
-        #     conn.rollback()
-        # finally:
-        #     self._close_cursor(cursor)
-        #     self._close_connection(conn)
-        # return results
+        return await self.repository.get_jobs_by_policy(ref_type, ref_id)
 
     async def list_jobs(
         self, state: Optional[str | list[str]] = None, batch_size: int = 0
@@ -2634,9 +2598,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
             if policy == ExistingWorkPolicy.REJECT_ALL:
                 return False
 
-            existing_jobs = await self._loop.run_in_executor(
-                self._db_executor, self.get_jobs_for_policy, work_info
-            )
+            existing_jobs = await self.get_jobs_for_policy(work_info)
 
             if policy == ExistingWorkPolicy.REJECT_DUPLICATE:
                 return len(existing_jobs) == 0
@@ -2648,16 +2610,17 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                 distinct_dag_ids = {
                     job.dag_id for job in existing_jobs if job.dag_id is not None
                 }
+                ref_id = work_info.data.get("metadata", {}).get("ref_id", "")
+                self.logger.warning(
+                    f"Job: {work_info.id}. {len(distinct_dag_ids)} existing dags with ref_id: {ref_id}"
+                )
                 for dag_id in distinct_dag_ids:
-                    dag_state = self._resolve_dag_status_sync(dag_id)
+                    dag_state = await self.repository.resolve_dag_state(dag_id)
                     if dag_state not in ("completed", "failed"):
                         self.logger.warning(
                             f"Removing DAG to due to 'replace' policy: {dag_id}, state: {dag_state}"
                         )
-                        self._remove_dag_from_memory(
-                            dag_id, "Existing Work Policy: 'replace'"
-                        )
-                        is_deleted = await self.delete_dag(dag_id)
+                        is_deleted = await self.repository.delete_dag(dag_id)
                         if not is_deleted:
                             self.logger.warning(f"Failed to delete DAG: {dag_id}")
                             return False
@@ -2672,28 +2635,6 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                 f"with policy '{policy}': {str(e)}"
             )
             return False
-
-    async def delete_dag(self, dag_id: str) -> bool:
-        self.logger.info(f"Deleting dag_id : {dag_id}")
-
-        # todo
-        def db_call():
-            cursor = None
-            conn = None
-            try:
-                conn = self._get_connection()
-                self._execute_sql_gracefully(
-                    delete_dags_and_jobs(DEFAULT_SCHEMA, [dag_id]), connection=conn
-                )
-                return True
-            except (Exception, psycopg2.Error) as error:
-                self.logger.error(f"Error completing failed job: {error}")
-                return False
-            finally:
-                self._close_cursor(cursor)
-                self._close_connection(conn)
-
-        return await self._loop.run_in_executor(self._db_executor, db_call)
 
     def stop_job(self, job_id: str) -> bool:
         """Request a job to exit, fire and forget.

--- a/marie/scheduler/psql.py
+++ b/marie/scheduler/psql.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from math import inf
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Set
 
 import psycopg2
 
@@ -58,7 +58,7 @@ from marie.scheduler.services import (
     MaintenanceService,
     NotificationService,
 )
-from marie.scheduler.state import WorkState
+from marie.scheduler.state import WorkState, is_terminal_state
 from marie.scheduler.util import (
     adjust_backoff,
     available_slots_by_executor,
@@ -213,7 +213,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
 
         # Register handler for DAG state changes (delegate to DAGManagementService)
         self.notification_service.register_handler(
-            channel='dag_state_changed', handler=self.dag_service.handle_state_change
+            channel="dag_state_changed", handler=self.dag_service.handle_state_change
         )
 
         # Initialize MaintenanceService for periodic cleanup tasks
@@ -415,7 +415,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
 
     def _is_branch_node(self, node) -> bool:
         """Check if a node is a BRANCH or SWITCH node."""
-        if not node or not hasattr(node, 'definition'):
+        if not node or not hasattr(node, "definition"):
             return False
 
         # Check if it's a BRANCH or SWITCH query type
@@ -425,7 +425,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
 
     def _is_guardrail_node(self, node) -> bool:
         """Check if a node is a GUARDRAIL node."""
-        if not node or not hasattr(node, 'definition'):
+        if not node or not hasattr(node, "definition"):
             return False
 
         return isinstance(node.definition, GuardrailQueryDefinition)
@@ -641,7 +641,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                     "selected_path_ids": active_path_ids,
                     "evaluation_mode": (
                         branch_def.evaluation_mode.value
-                        if hasattr(branch_def.evaluation_mode, 'value')
+                        if hasattr(branch_def.evaluation_mode, "value")
                         else branch_def.evaluation_mode
                     ),
                     "default_path_id": branch_def.default_path_id,
@@ -717,7 +717,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
 
                 # Add default case nodes to all targets
                 if branch_def.default_case:
-                    path_to_nodes['default'] = branch_def.default_case
+                    path_to_nodes["default"] = branch_def.default_case
                     all_target_nodes.update(branch_def.default_case)
 
             # Nodes to skip are all targets minus active targets
@@ -1088,6 +1088,8 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
         - DELETE: {'dag_id': '<id>', 'op': 'DELETE'}
 
         :param payload: The notification payload with minimal fields (dag_id, state, op)
+
+        .. note:: Not used. Duplicates :meth:`marie.scheduler.services.dag_management_service.DAGManagementService.handle_state_change`
         """
         try:
             op = payload.get("op")
@@ -1648,12 +1650,12 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                 for job_name, ids in ids_by_job_name.items():
                     try:
                         self.logger.info(
-                            f'[WORK_DIST] Attempting DB lease for job={job_name}, count={len(ids)}'
+                            f"[WORK_DIST] Attempting DB lease for job={job_name}, count={len(ids)}"
                         )
                         got = await self._lease_jobs_db(job_name, ids)
                         leased_ids.update(got)
                         self.logger.info(
-                            f'[WORK_DIST] DB lease result for job={job_name}: leased {len(got)}/{len(ids)}'
+                            f"[WORK_DIST] DB lease result for job={job_name}: leased {len(got)}/{len(ids)}"
                         )
                         if len(got) < len(ids):
                             missing_ids = set(ids) - set(got)
@@ -1769,7 +1771,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                             self._semaphore_store.reserve,
                             slot_type,
                             wi.id,  # ticket_id
-                            node='',  # at this time we don't know the placement where the job wil be executed yet
+                            node="",  # at this time we don't know the placement where the job wil be executed yet
                             ttl=self._sem_default_ttl,
                             owner=wi.id,
                         )
@@ -1976,7 +1978,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                 try:
                     await asyncio.wait_for(task, timeout)
                 except asyncio.TimeoutError:
-                    task_name = getattr(task, '_name', task.__class__.__name__)
+                    task_name = getattr(task, "_name", task.__class__.__name__)
                     self.logger.warning(
                         f"Task did not complete in time, cancelling it : {task_name}"
                     )
@@ -2132,8 +2134,8 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
             # These are needed by executors to record asset materializations
             job_metadata = work_info.data.copy()
             if work_info.dag_id:
-                job_metadata['dag_id'] = work_info.dag_id
-                job_metadata['node_task_id'] = (
+                job_metadata["dag_id"] = work_info.dag_id
+                job_metadata["node_task_id"] = (
                     work_info.id
                 )  # job ID serves as node task ID
 
@@ -2196,7 +2198,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
 
         return work_item
 
-    async def get_jobs_for_policy(self, work_info: WorkInfo) -> List[WorkInfo]:
+    async def get_dags_for_policy(self, work_info: WorkInfo) -> Set[str]:
         """
         Find a job by its name and data (used for policy checks).
         :param work_info: WorkInfo containing metadata with ref_type and ref_id
@@ -2205,7 +2207,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
         ref_type = work_info.data.get("metadata", {}).get("ref_type", "")
         ref_id = work_info.data.get("metadata", {}).get("ref_id", "")
 
-        return await self.repository.get_jobs_by_policy(ref_type, ref_id)
+        return await self.repository.get_dags_by_policy(ref_type, ref_id)
 
     async def list_jobs(
         self, state: Optional[str | list[str]] = None, batch_size: int = 0
@@ -2589,41 +2591,48 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
         :raises ValueError: If an unsupported policy is provided
         """
         try:
-            if policy in (
-                ExistingWorkPolicy.ALLOW_ALL,
-                ExistingWorkPolicy.ALLOW_DUPLICATE,
-            ):
+            if policy == ExistingWorkPolicy.ALLOW_ALL:
                 return True
 
             if policy == ExistingWorkPolicy.REJECT_ALL:
                 return False
 
-            existing_jobs = await self.get_jobs_for_policy(work_info)
+            existing_dags = await self.get_dags_for_policy(work_info)
 
             if policy == ExistingWorkPolicy.REJECT_DUPLICATE:
-                return len(existing_jobs) == 0
+                return len(existing_dags) == 0
 
             if policy == ExistingWorkPolicy.REPLACE:
-                if len(existing_jobs) == 0:
+                if len(existing_dags) == 0:
                     return True
 
-                distinct_dag_ids = {
-                    job.dag_id for job in existing_jobs if job.dag_id is not None
-                }
                 ref_id = work_info.data.get("metadata", {}).get("ref_id", "")
                 self.logger.warning(
-                    f"Job: {work_info.id}. {len(distinct_dag_ids)} existing dags with ref_id: {ref_id}"
+                    f"Job: {work_info.id}. {len(existing_dags)} existing dags with ref_id: {ref_id}"
                 )
-                for dag_id in distinct_dag_ids:
+                for dag_id in existing_dags:
                     dag_state = await self.repository.resolve_dag_state(dag_id)
-                    if dag_state not in ("completed", "failed"):
+                    if not is_terminal_state(dag_state):
                         self.logger.warning(
-                            f"Removing DAG to due to 'replace' policy: {dag_id}, state: {dag_state}"
+                            f"Cancelling DAG to due to policy: {policy}, dag_id: {dag_id}, state: {dag_state}"
                         )
-                        is_deleted = await self.repository.delete_dag(dag_id)
-                        if not is_deleted:
-                            self.logger.warning(f"Failed to delete DAG: {dag_id}")
-                            return False
+                        cancelled = await self.repository.cancel_pending_jobs_for_dag(
+                            dag_id=dag_id,
+                            output_metadata={
+                                "on_complete": WorkState.CANCELLED.value,  # Q: current values are done and failed. populated to jobs.output, doesn't seem to be used anywhere?
+                                "cancel_reason": f"Removing due to policy: {policy}",
+                                "terminal_dag_state": WorkState.CANCELLED.value,
+                                "resolved_by_job_id": work_info.id,
+                            },
+                        )
+                        self.logger.debug(
+                            f"Cancelled {cancelled} jobs for DAG: {dag_id}"
+                        )
+                        dag_state = await self.repository.resolve_dag_state(dag_id)
+                        if dag_state != WorkState.CANCELLED.value:
+                            self.logger.warning(
+                                f"Cancellation of existing DAG {dag_id} failed. State: {dag_state}"
+                            )
 
                 return True
 
@@ -3019,7 +3028,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                             self.repository.resolve_dag_state(dag_id), self._loop
                         )
                         dag_state = future.result(timeout=30)
-                        if dag_state in ("completed", "failed"):
+                        if is_terminal_state(dag_state):
                             resolved_terminal_dags.add(dag_id)
                     except Exception as resolve_error:
                         self.logger.warning(
@@ -3265,7 +3274,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                     dag_state = await self.repository.resolve_dag_state(dag_id)
 
                     self.logger.info(f"Resolved DAG state: {dag_state}")
-                    if dag_state not in ("completed", "failed"):
+                    if not is_terminal_state(dag_state):
                         self.logger.debug(f"DAG is still in progress: {dag_id}")
                         return False
 
@@ -3286,7 +3295,7 @@ class PostgreSQLJobScheduler(PostgresqlMixin, JobScheduler):
                             f"Removed DAG from cache: {dag_id}, size = {len(self.active_dags)}"
                         )
 
-                    if dag_state == "failed":
+                    if not WorkState(dag_state.lower()).is_successful_terminal():
                         cancelled = await self.repository.cancel_pending_jobs_for_dag(
                             dag_id=dag_id,
                             output_metadata={

--- a/marie/scheduler/repository/job_repository.py
+++ b/marie/scheduler/repository/job_repository.py
@@ -25,6 +25,7 @@ from marie.scheduler.repository.plans import (
     count_dag_states,
     count_job_states,
     create_queue,
+    delete_dags_and_jobs,
     fail_jobs_by_id,
     insert_dag,
     insert_job,
@@ -150,6 +151,60 @@ class JobRepository(PostgresqlMixin):
             finally:
                 self._close_cursor(cursor)
                 self._close_connection(conn)
+
+        return await self._loop.run_in_executor(self._db_executor, db_call)
+
+    async def get_jobs_by_policy(
+        self, ref_type: str, ref_id: str
+    ) -> Optional[WorkInfo]:
+        """
+        Find a job by its reference type and reference ID.
+
+        :param ref_type: Reference type from job metadata
+        :param ref_id: Reference ID from job metadata
+        :return: WorkInfo object if found, None otherwise
+        """
+
+        def db_call():
+            cursor = None
+            conn = None
+            results = []
+            try:
+                conn = self._get_connection()
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                        SELECT
+                        id,
+                        name,
+                        priority,
+                        state,
+                        retry_limit,
+                        start_after,
+                        expire_in,
+                        data,
+                        retry_delay,
+                        retry_backoff,
+                        keep_until,
+                        dag_id,
+                        job_level
+                    FROM {DEFAULT_SCHEMA}.{DEFAULT_JOB_TABLE}
+                    WHERE data->'metadata'->>'ref_type' = '{ref_type}'
+                    AND data->'metadata'->>'ref_id' = '{ref_id}'
+                    """
+                )
+                results = [
+                    self._record_to_work_info(record) for record in cursor.fetchall()
+                ]
+                conn.commit()
+            except (Exception, psycopg2.Error) as error:
+                self.logger.error(f"Error getting job: {error}")
+                if conn:
+                    conn.rollback()
+            finally:
+                self._close_cursor(cursor)
+                self._close_connection(conn)
+            return results
 
         return await self._loop.run_in_executor(self._db_executor, db_call)
 
@@ -1561,6 +1616,27 @@ class JobRepository(PostgresqlMixin):
             except (Exception, psycopg2.Error) as error:
                 self.logger.error(f"Error completing job: {error}")
                 return 0
+            finally:
+                self._close_cursor(cursor)
+                self._close_connection(conn)
+
+        return await self._loop.run_in_executor(self._db_executor, db_call)
+
+    async def delete_dag(self, dag_id: str) -> bool:
+        self.logger.info(f"Deleting dag_id : {dag_id}")
+
+        def db_call():
+            cursor = None
+            conn = None
+            try:
+                conn = self._get_connection()
+                self._execute_sql_gracefully(
+                    delete_dags_and_jobs(DEFAULT_SCHEMA, [dag_id]), connection=conn
+                )
+                return True
+            except (Exception, psycopg2.Error) as error:
+                self.logger.error(f"Error completing failed job: {error}")
+                return False
             finally:
                 self._close_cursor(cursor)
                 self._close_connection(conn)

--- a/marie/scheduler/repository/job_repository.py
+++ b/marie/scheduler/repository/job_repository.py
@@ -43,6 +43,7 @@ from marie.storage.database.postgres import PostgresqlMixin
 
 DEFAULT_SCHEMA = "marie_scheduler"
 DEFAULT_JOB_TABLE = "job"
+DEFAULT_DAG_TABLE = "dag"
 
 
 class JobRepository(PostgresqlMixin):
@@ -154,9 +155,7 @@ class JobRepository(PostgresqlMixin):
 
         return await self._loop.run_in_executor(self._db_executor, db_call)
 
-    async def get_jobs_by_policy(
-        self, ref_type: str, ref_id: str
-    ) -> Optional[WorkInfo]:
+    async def get_dags_by_policy(self, ref_type: str, ref_id: str) -> Set[str]:
         """
         Find a job by its reference type and reference ID.
 
@@ -168,35 +167,22 @@ class JobRepository(PostgresqlMixin):
         def db_call():
             cursor = None
             conn = None
-            results = []
+            dag_ids = []
             try:
                 conn = self._get_connection()
                 cursor = conn.cursor()
                 cursor.execute(
-                    f"""
-                        SELECT
-                        id,
-                        name,
-                        priority,
-                        state,
-                        retry_limit,
-                        start_after,
-                        expire_in,
-                        data,
-                        retry_delay,
-                        retry_backoff,
-                        keep_until,
-                        dag_id,
-                        job_level
-                    FROM {DEFAULT_SCHEMA}.{DEFAULT_JOB_TABLE}
-                    WHERE data->'metadata'->>'ref_type' = '{ref_type}'
-                    AND data->'metadata'->>'ref_id' = '{ref_id}'
+                    f"""                    
+                    SELECT DISTINCT dag_id
+                    FROM {DEFAULT_SCHEMA}.{DEFAULT_JOB_TABLE} j
+                        JOIN {DEFAULT_SCHEMA}.{DEFAULT_DAG_TABLE} d on j.dag_id = d.id and d.state <> '{WorkState.CANCELLED.value}'
+                    WHERE j.data->'metadata'->>'ref_type' = '{ref_type}'
+                    AND j.data->'metadata'->>'ref_id' = '{ref_id}'
                     """
                 )
-                results = [
-                    self._record_to_work_info(record) for record in cursor.fetchall()
-                ]
+                results = cursor.fetchall()
                 conn.commit()
+                dag_ids = {str(record[0]) for record in results}
             except (Exception, psycopg2.Error) as error:
                 self.logger.error(f"Error getting job: {error}")
                 if conn:
@@ -204,7 +190,7 @@ class JobRepository(PostgresqlMixin):
             finally:
                 self._close_cursor(cursor)
                 self._close_connection(conn)
-            return results
+            return dag_ids
 
         return await self._loop.run_in_executor(self._db_executor, db_call)
 
@@ -956,7 +942,7 @@ class JobRepository(PostgresqlMixin):
                 cursor = conn.cursor()
 
                 # Build parameterized query
-                placeholders = ','.join(['%s'] * len(dag_ids))
+                placeholders = ",".join(["%s"] * len(dag_ids))
                 query = f"""
                     SELECT id FROM {DEFAULT_SCHEMA}.dag
                     WHERE id IN ({placeholders}) AND state = 'active'
@@ -1349,7 +1335,7 @@ class JobRepository(PostgresqlMixin):
         query_file = os.path.join(tmp_path, f"locked_query_{timestamp}.sql")
 
         try:
-            with open(query_file, 'w') as f:
+            with open(query_file, "w") as f:
                 f.write(locked_query)
             self.logger.info(f"Wrote locked query to: {query_file}")
         except Exception as e:
@@ -1681,7 +1667,7 @@ class JobRepository(PostgresqlMixin):
                 final_state = result[1] if len(result) > 1 else None
 
                 if count > 0:
-                    if final_state == 'retry':
+                    if final_state == "retry":
                         self.logger.info(
                             f"Job {job_id} marked for retry (will be retried)"
                         )
@@ -1773,7 +1759,7 @@ class JobRepository(PostgresqlMixin):
         """
         Close the repository and cleanup resources.
         """
-        if hasattr(self, '_db_executor'):
+        if hasattr(self, "_db_executor"):
             self._db_executor.shutdown(wait=True)
-        if hasattr(self, 'postgreSQL_pool'):
+        if hasattr(self, "postgreSQL_pool"):
             self.postgreSQL_pool.closeall()

--- a/marie/scheduler/repository/plans.py
+++ b/marie/scheduler/repository/plans.py
@@ -373,6 +373,11 @@ def fetch_next_job(schema: str):
     return query
 
 
+def delete_dags_and_jobs(schema: str, ids: list) -> str:
+    ids_string = "ARRAY[" + ",".join(f"'{str(_id)}'" for _id in ids) + "]"
+    return f"select {schema}.delete_dags_and_jobs({ids_string}::uuid[])"
+
+
 def mark_as_active_jobs(
     schema: str, name: str, ids: list, include_metadata: bool = False
 ):


### PR DESCRIPTION
The "Replace" Existing Work policy was present in version 4.0 (#178) and still needed in 4.5 for extract and corr

- JIRA: AP-3034
- Implementation of "replace" Existing Work  policy for Marie v4.5
