### PR TITLE
feat: Safe encoding, BoxProcessorUlimDit.psm_sparse

### DIFF
--- a/marie/executor/text/text_extraction_executor.py
+++ b/marie/executor/text/text_extraction_executor.py
@@ -381,6 +381,7 @@ class TextExtractionExecutor(MarieExecutor, StorageMixin):
                                 bboxes.append(line["bbox"])
 
                 if bboxes:
+                    bboxes = safely_encoded(lambda x: x)(bboxes)
                     bbox_bytes = json.dumps(bboxes).encode("utf-8")
                     bbox_version = AssetTracker.compute_asset_version(
                         payload_bytes=bbox_bytes,


### PR DESCRIPTION
Resolves: 
```
ERROR  2026-04-02 19:46:16,005:069cf0c9-cb8f-7f84-8000-097a4110853b : TextExtractionExecutor[]@3955098 Extract error : Object of type int32 is not JSON          [04/02/26 19:46:16]
       serializable                                                                                                                                                                 
       Traceback (most recent call last):                                                                                                                                           
         File "/home/rdraviam/dev/marie-ai/marie/executor/text/text_extraction_executor.py", line 238, in extract                                                                   
           self.persist(                                                                                                                                                            
         File "/home/rdraviam/dev/marie-ai/marie/executor/text/text_extraction_executor.py", line 384, in persist                                                                   
           bbox_bytes = json.dumps(bboxes).encode("utf-8")                                                                                                                          
                        ^^^^^^^^^^^^^^^^^^                                                                                                                                          
         File "/usr/lib/python3.12/json/__init__.py", line 231, in dumps                                                                                                            
           return _default_encoder.encode(obj)                                                                                                                                      
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                      
         File "/usr/lib/python3.12/json/encoder.py", line 200, in encode                                                                                                            
           chunks = self.iterencode(o, _one_shot=True)                                                                                                                              
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                              
         File "/usr/lib/python3.12/json/encoder.py", line 258, in iterencode                                                                                                        
           return _iterencode(o, 0)                                                                                                                                                 
                  ^^^^^^^^^^^^^^^^^                                                                                                                                                 
         File "/usr/lib/python3.12/json/encoder.py", line 180, in default                                                                                                           
           raise TypeError(f'Object of type {o.__class__.__name__} '                                                                                                                
       TypeError: Object of type int32 is not JSON serializable                                                                                                                     
INFO   2026-04-02 19:46:16,009:            : extract_executor/rep-0[]@3955098 [callback] executor_completion_callback invoked for                                                   
       job_id=069cf0c9-cb8f-7f84-8000-097a4110853b, has_exception=False                                                                                                             
ERROR  2026-04-02 19:46:16,009:            : extract_executor/rep-0[]@3955098 Executor returned error status for job_id=069cf0c9-cb8f-7f84-8000-097a4110853b:                       
       ('Object of type int32 is not JSON serializable',)
```
- JIRA: AP-3043
