### PR TITLE
Fix: extract assets named correctly when RefId is not a filename

### DIFF
--- a/marie/pipe/components.py
+++ b/marie/pipe/components.py
@@ -430,7 +430,10 @@ def burst_frames(
     :return:
     """
     output_dir = ensure_exists(os.path.join(root_asset_dir, "burst"))
+    # NOTE: filename = prefix = refId when refId is not a filename
     filename, prefix, suffix = split_filename(ref_id)
+    suffix = suffix or "tif"
+
     filename_generator = partial(filename_supplier_page, filename, prefix, suffix)
 
     file_count = get_file_count(output_dir)

--- a/marie/pipe/extract_pipeline.py
+++ b/marie/pipe/extract_pipeline.py
@@ -575,6 +575,7 @@ class ExtractPipeline(BasePipeline):
         adlib_dir = ensure_exists(os.path.join(root_asset_dir, "adlib"))
         self.logger.info(f"Rendering adlib : {adlib_dir}")
 
+        # NOTE: filename = prefix = refId when refId is not a filename
         filename, prefix, suffix = split_filename(ref_id)
         renderer = AdlibRenderer(summary_filename=f"{filename}.xml", config={})
 
@@ -582,7 +583,9 @@ class ExtractPipeline(BasePipeline):
             frames,
             results,
             adlib_dir,
-            filename_generator=lambda x: f"{prefix}_{x}.{suffix}.xml",
+            filename_generator=lambda x: (
+                f"{prefix}_{x}.xml" if not suffix else f"{prefix}_{x}.{suffix}.xml"
+            ),
         )
 
     def pack_assets(
@@ -597,8 +600,12 @@ class ExtractPipeline(BasePipeline):
 
         filename, prefix, suffix = split_filename(ref_id)
 
-        merge_zip(adlib_dir, os.path.join(assets_dir, f"{prefix}.ocr.zip"))
-        merge_zip(blob_dir, os.path.join(assets_dir, f"{prefix}.blobs.xml.zip"))
+        merge_zip(
+            adlib_dir, os.path.join(assets_dir, f"{prefix}.ocr.zip"), f"{prefix}*"
+        )
+        merge_zip(
+            blob_dir, os.path.join(assets_dir, f"{prefix}.blobs.xml.zip"), f"{prefix}*"
+        )
 
         # convert multiple to G4 standard (mulitpage) TIFF
         clean_filename = os.path.join(assets_dir, f"{prefix}.clean.tif")


### PR DESCRIPTION
Changes:
- Assets in /burst/ and /adlib/ directory are named correctly when RefId is not a filename that ends in `.tif` 
Ex. RefID 123456789
    - burst: `123456789_00001.` -> `123456789_00001.tif`
    - adlib: `123456789_1..xml` -> `123456789_1.xml`
- Adlib and Blob zips only aggregate files with filenames beginning with RefId (case when image with the same hash is submitted with different RefIds)

JIRA: AP-2667