### PR TITLE
feat(record_backed): Add records_required flag to match_section_source.

### DIFF
--- a/marie/extract/engine/record_backed_match_section_builder_visitor.py
+++ b/marie/extract/engine/record_backed_match_section_builder_visitor.py
@@ -66,6 +66,7 @@ class RecordBackedMatchSectionBuilderVisitor(BaseProcessingVisitor):
             )
 
         envelope_key = match_section_source.get("envelope_key")
+        records_required = match_section_source.get("records_required", True)
 
         records = load_extracted_records(
             output_dir=str(context.output_dir),
@@ -73,7 +74,7 @@ class RecordBackedMatchSectionBuilderVisitor(BaseProcessingVisitor):
             envelope_key=envelope_key,
         )
 
-        if not records:
+        if not records and records_required:
             raise ValueError(
                 f"Layer '{layer.layer_name}': strategy 'record_backed' "
                 f"but no records found in data_source '{data_source}'. "


### PR DESCRIPTION
**Goal:**
* Resolves job failure when a layer's `data_source` exists, but the `envelop_key` does not contain any data as long as the `match_section_source` has the attribute `records_required: false`. (ex. PLBs on medical records may or may not exist).

**Details:**
* `records_required` defaults to True (no change to existing behavior).
* If `records_required` is False, a `ValueError` will not be thrown if no records are found.

*NOTE: Use case documentation on has been added to another repo.
