### PR TITLE
fix: exponential number of inferences

### DIFF
--- a/marie/components/document_classifier/transformers.py
+++ b/marie/components/document_classifier/transformers.py
@@ -205,14 +205,15 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
 
         batches = batch_iterator(batchable_docs, batch_size)
         predictions = []
-        pb = tqdm(
-            total=len(documents),
-            disable=not self.progress_bar,
-            desc="Classifying documents",
-        )
 
         id2label = self.id2label
-        for batch in batches:
+        for batch in tqdm(
+            batches,
+            desc=f"Running Inference (batch size: {batch_size})",
+            unit="batch",
+            delay=0.1,
+            disable=not self.progress_bar,
+        ):
             batch_results = []
             if self.task == "zero-shot-classification":
                 batch_results = self.model(
@@ -265,10 +266,8 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
                         self.logger.error(err_msg)
                     else:
                         self.logger.debug(err_msg)
-
             elif self.task == "text-classification-multimodal":
-                batch_results = []
-                for doc in batchable_docs:
+                for doc in batch:
                     batch_results.append(
                         self.predict_document_image(
                             doc.tensor,
@@ -279,8 +278,6 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
                     )
 
             predictions.extend(batch_results)
-            pb.update(len(batch))
-        pb.close()
 
         for document, prediction in zip(documents, predictions):
             if (


### PR DESCRIPTION
**Issue:** `TransformersDocumentClassifier` iterates through _all_ pages every batch for `text-classification-multimodal` tasks. 
- Ie. if batch size is 1
  - 1 page = 1 inference
  - 10  pages =  100 inferences
  -  100 pages = 10,000 inferences

**Fix:** Nested for loop iterates through each item in the batch instead of each item in batchable_docs.

**Note**: Affects mpc & corr routing